### PR TITLE
fix: hover時にtooltipが見切れる問題を修正

### DIFF
--- a/src/scss/components/_grid.scss
+++ b/src/scss/components/_grid.scss
@@ -3,6 +3,7 @@
   position: absolute;
   top: 0;
   bottom: 0;
+  overflow-x: hidden;
 }
 
 .rt-grid {

--- a/src/scss/components/_layout.scss
+++ b/src/scss/components/_layout.scss
@@ -24,6 +24,4 @@
   vertical-align: top;
 }
 
-.rt-layout__timeline {
-  overflow-x: auto;
-}
+.rt-layout__timeline {}

--- a/src/scss/components/_timeline.scss
+++ b/src/scss/components/_timeline.scss
@@ -1,6 +1,5 @@
 .rt-timeline {
   position: relative;
-  overflow: hidden;
 }
 
 .rt-timeline__header {}

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -43,7 +43,6 @@ $react-timelines-button-size: 44px !default;
 .rt {
   position: relative;
   z-index: 1;
-  overflow: hidden;
   font-family: $react-timelines-font-family;
   color: $react-timelines-text-color;
   margin: 3px 0px;


### PR DESCRIPTION
## 概要
- 標題の通りです
- `overflow-x` の設定を調整した

## キャプチャ
<img width="123" alt="image" src="https://github.com/hr-hsugiyama/react-timelines-typescript/assets/106657355/6977f553-a4ce-4b18-aeea-7bf532cf60a1">
