### PR TITLE
枠背景のクリック時にイベントを発火させるようにする

### DIFF
--- a/src/components/Layout/index.jsx
+++ b/src/components/Layout/index.jsx
@@ -141,6 +141,7 @@ class Layout extends PureComponent {
       sidebarWidth,
       timelineViewportWidth,
       clickElement,
+      clickTrack,
       clickTrackButton,
       cornerDomAdd,
     } = this.props
@@ -175,6 +176,7 @@ class Layout extends PureComponent {
                 scrollLeft,
               }}
               clickElement={clickElement}
+              clickTrack={clickTrack}
             />
           </div>
         </div>
@@ -199,6 +201,7 @@ Layout.propTypes = {
   sidebarWidth: PropTypes.number,
   timelineViewportWidth: PropTypes.number,
   clickElement: PropTypes.func,
+  clickTrack: PropTypes.func,
   clickTrackButton: PropTypes.func,
   cornerDomAdd: PropTypes.func,
 }

--- a/src/components/Timeline/Body.jsx
+++ b/src/components/Timeline/Body.jsx
@@ -4,10 +4,10 @@ import PropTypes from 'prop-types'
 import Tracks from './Tracks'
 import Grid from './Grid'
 
-const Body = ({ time, grid, tracks, clickElement }) => (
+const Body = ({ time, grid, tracks, clickElement, clickTrack }) => (
   <div className="rt-timeline__body">
     {grid && <Grid time={time} grid={grid} />}
-    <Tracks time={time} tracks={tracks} clickElement={clickElement} />
+    <Tracks time={time} tracks={tracks} clickElement={clickElement} clickTrack={clickTrack} />
   </div>
 )
 

--- a/src/components/Timeline/Tracks/Track.jsx
+++ b/src/components/Timeline/Tracks/Track.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import Tracks from '.'
 import Element from './Element'
 
-const Track = ({ time, elements, isOpen, tracks, clickElement, style }) => (
+const Track = ({ trackKey, time, elements, isOpen, tracks, clickElement, clickTrack, style }) => (
   <div className="tr-track">
     <div className="rt-track__elements" style={style}>
       {elements
@@ -12,21 +12,36 @@ const Track = ({ time, elements, isOpen, tracks, clickElement, style }) => (
         .map(element => (
           <Element key={element.id} time={time} clickElement={clickElement} {...element} />
         ))}
+      {clickTrack && style && (
+        <div
+          className="rt-track__collider"
+          onClick={() => {
+            console.log(trackKey)
+            clickTrack(trackKey)
+          }}
+          style={{ height: style.height }}
+        />
+      )}
     </div>
-    {isOpen && tracks && tracks.length > 0 && <Tracks time={time} tracks={tracks} clickElement={clickElement} />}
+    {isOpen && tracks && tracks.length > 0 && (
+      <Tracks time={time} tracks={tracks} clickElement={clickElement} clickTrack={clickTrack} />
+    )}
   </div>
 )
 
 Track.propTypes = {
+  trackKey: PropTypes.number,
   time: PropTypes.shape({}).isRequired,
   isOpen: PropTypes.bool,
   elements: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   tracks: PropTypes.arrayOf(PropTypes.shape({})),
   clickElement: PropTypes.func,
+  clickTrack: PropTypes.func,
 }
 
 Track.defaultProps = {
   clickElement: undefined,
+  clickTrack: undefined,
 }
 
 export default Track

--- a/src/components/Timeline/Tracks/Track.jsx
+++ b/src/components/Timeline/Tracks/Track.jsx
@@ -16,7 +16,6 @@ const Track = ({ trackKey, time, elements, isOpen, tracks, clickElement, clickTr
         <div
           className="rt-track__collider"
           onClick={() => {
-            console.log(trackKey)
             clickTrack(trackKey)
           }}
           style={{ height: style.height }}

--- a/src/components/Timeline/Tracks/index.jsx
+++ b/src/components/Timeline/Tracks/index.jsx
@@ -3,16 +3,19 @@ import PropTypes from 'prop-types'
 
 import Track from './Track'
 
-const Tracks = ({ time, tracks, clickElement }) => (
+const Tracks = ({ time, tracks, clickElement, clickTrack }) => (
   <div className="rt-tracks">
-    {tracks.map(({ id, elements, isOpen, tracks: children, style }) => (
+    {tracks.map(({ id, churchId, title, elements, isOpen, tracks: children, style }) => (
       <Track
         key={id}
+        title={title}
+        churchId={churchId}
         time={time}
         elements={elements}
         isOpen={isOpen}
         tracks={children}
         clickElement={clickElement}
+        clickTrack={clickTrack}
         style={style}
       />
     ))}
@@ -23,6 +26,7 @@ Tracks.propTypes = {
   time: PropTypes.shape({}).isRequired,
   tracks: PropTypes.arrayOf(PropTypes.shape({})),
   clickElement: PropTypes.func,
+  clickTrack: PropTypes.func,
 }
 
 export default Tracks

--- a/src/components/Timeline/index.jsx
+++ b/src/components/Timeline/index.jsx
@@ -33,7 +33,7 @@ class Timeline extends Component {
   }
 
   render() {
-    const { now, markerText, time, timebar, tracks, sticky, clickElement, isDisplayPointer } = this.props
+    const { now, markerText, time, timebar, tracks, sticky, clickElement, clickTrack, isDisplayPointer } = this.props
 
     const { pointerDate, pointerVisible, pointerHighlighted } = this.state
 
@@ -54,7 +54,7 @@ class Timeline extends Component {
           width={time.timelineWidthStyle}
           sticky={sticky}
         />
-        <Body time={time} grid={grid} tracks={tracks} clickElement={clickElement} />
+        <Body time={time} grid={grid} tracks={tracks} clickElement={clickElement} clickTrack={clickTrack} />
       </div>
     )
   }
@@ -76,6 +76,7 @@ Timeline.propTypes = {
   tracks: PropTypes.arrayOf(PropTypes.shape({})),
   sticky: PropTypes.shape({}),
   clickElement: PropTypes.func,
+  clickTrack: PropTypes.func,
   isDisplayPointer: PropTypes.bool,
 }
 

--- a/src/scss/components/_track.scss
+++ b/src/scss/components/_track.scss
@@ -11,3 +11,10 @@
   position: absolute;
   height: $react-timelines-track-height - 2 * $react-timelines-element-spacing;
 }
+
+.rt-track__collider {
+  position: relative;
+  height: $react-timelines-track-height - 2 * $react-timelines-element-spacing;
+  border-bottom: $react-timelines-border-width solid $react-timelines-keyline-color;
+  cursor: pointer;
+}

--- a/src/timeline.jsx
+++ b/src/timeline.jsx
@@ -58,6 +58,7 @@ export const Timeline = props => {
     enableSticky = false,
     scrollToNow,
     clickElement,
+    clickTrack,
     clickTrackButton,
     cornerDomAdd,
   } = props
@@ -89,6 +90,7 @@ export const Timeline = props => {
         timelineViewportWidth={state.timelineViewportWidth}
         sidebarWidth={state.sidebarWidth}
         clickElement={clickElement}
+        clickTrack={clickTrack}
         clickTrackButton={clickTrackButton}
         cornerDomAdd={cornerDomAdd}
       />
@@ -110,6 +112,7 @@ Timeline.propTypes = {
   zoomIn: PropTypes.func,
   zoomOut: PropTypes.func,
   clickElement: PropTypes.func,
+  clickTrack: PropTypes.func,
   clickTrackButton: PropTypes.func,
   timebar: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   tracks: PropTypes.arrayOf(PropTypes.shape({})).isRequired,


### PR DESCRIPTION
## 概要
- 枠背景をクリックした時のイベントを追加する
## やったこと
- `clickTrack` イベントを渡せるようにした
- `trackKey` propsを渡せるようにした
  - IDとは別で枠に紐付けたいデータのためのprops (あきコレではchurch_idを渡す)
## キャプチャ
- なし
## その他
- 先にマージしてしまいます。